### PR TITLE
Refactor targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 .RData
 .Ruserdata
 
+# Ignore pipeline data files
+*/out/*
 _targets/*

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,48 +1,91 @@
-
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
+download_nwis_data <- function(site_num, out_dir, startDate, endDate, parameterCd){
   
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  data_out <- data.frame()
-  # loop through files to download 
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
-    data_out <- bind_rows(data_out, these_data)
-  }
-  return(data_out)
-}
-
-nwis_site_info <- function(fileout, site_data){
-  site_no <- unique(site_data$site_no)
-  site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
-  return(fileout)
+  # function to simultaneously download site information and data for set parameter
+  
+    # create the file name needed for download_nwis_site_data
+      download_file <- file.path(out_dir, paste0("nwis_", site_num, "_nwisdata.csv"))
+        
+    # download parameter data
+      val <- retry(download_nwis_site_data(download_file, startDate, endDate, parameterCd = parameterCd), maxErrors = 10, sleep = 2)
+        
+    # download site info
+      val <- retry(download_nwis_site_info(site_num, out_dir), maxErrors = 10, sleep = 2)
+        
+      return(out_dir)
+  
 }
 
 
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
-  
-  # filepaths look something like directory/nwis_01432160_data.csv,
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
-  site_num <- basename(filepath) %>% 
-    stringr::str_extract(pattern = "(?:[0-9]+)")
-  
-  # readNWISdata is from the dataRetrieval package
-  data_out <- readNWISdata(sites=site_num, service="iv", 
-                           parameterCd = parameterCd, startDate = startDate, endDate = endDate)
 
-  # -- simulating a failure-prone web-sevice here, do not edit --
-  set.seed(Sys.time())
-  if (sample(c(T,F,F,F), 1)){
-    stop(site_num, ' has failed due to connection timeout. Try tar_make() again')
-  }
-  # -- end of do-not-edit block
+download_nwis_site_info <- function(site_num, out_dir){ 
   
-  write_csv(data_out, file = filepath)
-  return(filepath)
+  # function to access and download site information for set site number
+      
+      site_info <- dataRetrieval::readNWISsite(site_num)
+      readr::write_csv(site_info, paste0(out_dir, "nwis_", site_num, "_siteinfo.csv"))
+      return(paste0(out_dir, "nwis_", site_num, "_siteinfo.csv"))
+  
 }
 
+
+
+download_nwis_site_data <- function(filepath, parameterCd, startDate, endDate){ 
+  
+  # function to access and download data for set parameter
+  
+      site_num <- basename(filepath) %>% 
+        stringr::str_extract(pattern = "(?:[0-9]+)")
+      
+      data_out <- dataRetrieval::readNWISdata(
+        sites=site_num, 
+        service="iv", 
+        parameterCd = parameterCd, 
+        startDate = startDate, 
+        endDate = endDate
+        )
+  
+    # -- simulating a failure-prone web-service here, do not edit --
+      set.seed(Sys.time())
+      if (sample(c(T,F,F,F), 1)){
+        stop(site_num, ' has failed due to connection timeout. Try tar_make() again')
+      }
+    # -- end of do-not-edit block
+    
+      readr::write_csv(data_out, filepath)
+      return(filepath)
+    
+}
+
+
+
+retry <- function(expr, isError=function(x) "try-error" %in% class(x), maxErrors, sleep) { 
+  
+  # function to retry downloads within set number of attempts and wait period
+  
+      attempts = 0
+      retval = try(eval(expr))
+      
+      while (isError(retval)) {
+        
+        attempts = attempts + 1
+        if (attempts >= maxErrors) {
+          msg = sprintf("retry: too many retries [[%s]]", capture.output(str(retval)))
+          flog.fatal(msg)
+          stop(msg)
+          
+        } else {
+          
+          msg = sprintf("retry: error in attempt %i/%i [[%s]]", attempts, maxErrors, capture.output(str(retval)))
+          futile.logger::flog.error(msg)
+          warning(msg)
+          
+        }
+        
+        if (sleep > 0) Sys.sleep(sleep)
+        retval = try(eval(expr))
+        
+      }
+      
+      return(retval)
+  
+}

--- a/2_process/src/bind_data.R
+++ b/2_process/src/bind_data.R
@@ -1,0 +1,13 @@
+bind_data <- function(eval_data, search_string, file_outpath) {
+  
+  # Function to bind downloaded output files together
+  
+    filenames <- list.files(eval_data, pattern = paste0(search_string), full.names = TRUE)
+    ldf <- lapply(filenames, readr::read_csv)
+    combined_df <- do.call(rbind, ldf)
+    
+    readr::write_csv(file_outpath)
+    
+    return(file_outpath)
+  
+}

--- a/2_process/src/bind_data.R
+++ b/2_process/src/bind_data.R
@@ -6,7 +6,7 @@ bind_data <- function(eval_data, search_string, file_outpath) {
     ldf <- lapply(filenames, readr::read_csv)
     combined_df <- do.call(rbind, ldf)
     
-    readr::write_csv(file_outpath)
+    readr::write_csv(combined_df, file_outpath)
     
     return(file_outpath)
   

--- a/_targets.R
+++ b/_targets.R
@@ -1,5 +1,6 @@
 library(targets)
 source("1_fetch/src/get_nwis_data.R")
+source("2_process/src/bind_data.R")
 source("2_process/src/process_and_style.R")
 source("3_visualize/src/plot_timeseries.R")
 
@@ -52,9 +53,18 @@ p1_targets_list <- list(
       site_data,
       "nwisdata", # specify which files to combine, filename search string
       "2_process/out/all_nwisdata.csv" # file outpath
-    )
-  ),
+    ),
   format = "file"
+  ),
+  tar_target(
+    compiled_site_info,
+    bind_data(
+      site_data,
+      "nwisdata", # specify which files to combine, filename search string
+      "2_process/out/all_siteinfo.csv" # file outpath
+    ),
+    format = "file"
+  )
 )
 
 

--- a/_targets.R
+++ b/_targets.R
@@ -4,42 +4,82 @@ source("2_process/src/process_and_style.R")
 source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 
+tar_option_set(packages = c(
+  "tidyverse", 
+  "dataRetrieval",
+  "utils",
+  "futile.logger"
+  )
+)
+
+# site number list 
+site_list <- c("01427207", "01432160", "01436690", "01466500")
+
+# establish common start date, end date, and parameter code for queries
+startDate <- "2014-05-01" 
+endDate <- "2015-05-01"
+parameterCd <- '00010'
+
+# Create output directories if not included
+if(!dir.exists('1_fetch/out/'))
+  dir.create(path = '1_fetch/out/')
+if(!dir.exists('2_process/out/'))
+  dir.create(path = '2_process/out/')
+if(!dir.exists('3_visualize/out/'))
+  dir.create(path = '3_visualize/out/')
+
+
+
+# Download site data and compile files
 p1_targets_list <- list(
   tar_target(
     site_data,
-    download_nwis_data(),
+      for (site_num in site_list) {
+        download_nwis_data(
+          site_num,
+          "1_fetch/out/", # out directory
+          startDate,
+          endDate,
+          parameterCd
+        )
+      },
+    format = "file"
   ),
   tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
-    format = "file"
-  )
+    compiled_nwis_data,
+    bind_data(
+      site_data,
+      "nwisdata", # specify which files to combine, filename search string
+      "2_process/out/all_nwisdata.csv" # file outpath
+    )
+  ),
+  format = "file"
 )
 
-p2_targets_list <- list(
-  tar_target(
-    site_data_clean, 
-    process_data(site_data)
-  ),
-  tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
-  ),
-  tar_target(
-    site_data_styled,
-    style_data(site_data_annotated)
-  )
-)
 
-p3_targets_list <- list(
-  tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
-    format = "file"
-  )
-)
+#p2_targets_list <- list(
+#  tar_target(
+#    site_data_clean, 
+#    process_data(site_data)
+#  ),
+#  tar_target(
+#    site_data_annotated,
+#    annotate_data(site_data_clean, site_filename = site_info_csv)
+#  ),
+#  tar_target(
+#    site_data_styled,
+#    style_data(site_data_annotated)
+#  )
+#)
+
+#p3_targets_list <- list(
+#  tar_target(
+#    figure_1_png,
+#    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
+#    format = "file"
+#  )
+#)
 
 # Return the complete list of targets
-c(p1_targets_list, p2_targets_list, p3_targets_list)
+c(p1_targets_list)#, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
@lindsayplatt I created a PR for the code/question I had previously, regarding this approach I wanted to use in `p1_targets_list` to loop through a list of stations in the `site_data` target and rely on the directory for the next target. I receive an error from the `site_data` target:

`Error : _build_ target site_data did not return a character. dynamic files (targets with format = "file") must return character vectors of file or directory paths.`

I'm not sure if I'm missing something OR if I should just create a separate `site_data` type target for each station rather than looping.